### PR TITLE
29 cambiar comportamiento de config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.1.711] - 2022-09-15
+
+### Bugfixes
+
+- Error en la orientación de las imágenes
+- Correción del contador de imágenes en la patalla de Escaner
+- Habilitación del comportamiento que oculta el botón de captura mientras se está capturando la imagen.
+- Corregido un *bug* que hacía que después de una cantidad considerable de imágenes se incrementara el uso de la memoria RAM. Se corrigió modificando el comportamiento de *bagit* para que no se actualice el manifiesto con cada captura sino al cerrar el proyecto.
+- Corrección de la orientación de las imágenes (se mostraban invertidas).
+- Hallado error de sobreescritura. Se debía a un error no identificado por errores al guardar el archivo JSON que impedía identificar la siguiente imagen. Se creó un script para arreglar el archivo y poder continuar.
+
 ## [0.1.710] - 2022-07-26
 
 ### Bugfixes

--- a/filecontrol.py
+++ b/filecontrol.py
@@ -116,8 +116,10 @@ class DescargarIMGS:
             orient = 1
 
         # asegurar orientación correcta
-        img = Image(jpg_path)
-        img.orientation = orient
+        with open(jpg_path, 'rb') as fr: # V0.1.710 fixed error "str" object has no "read" attribute
+            img = Image(fr)
+            img.orientation = orient
+
         with open(jpg_path, 'wb') as fp:
             fp.write(img.get_file())
 

--- a/filecontrol.py
+++ b/filecontrol.py
@@ -15,15 +15,15 @@ import json
 import shutil
 import sys
 import chdkptp.util as util
-from pathlib import Path
 import os
 import datetime
 from db_handler import getElementIdByMetadata, wrap_imageWithElement
 from exif import Image
-import logging
 import configparser
 import bagit
 from logcontrol import LogControl as log
+import utils.fixJSON as fixJSON
+from json import JSONDecodeError
 
 # config
 
@@ -111,7 +111,7 @@ class DescargarIMGS:
                 self.nombre_proyecto, jpg_path, 'jpg')
         if orientacion == "vertical":
             img_num = int(jpg_path.split("/")[-1].split(".")[0])
-            orient = [8 if img_num % 2 == 0 else 6][0]
+            orient = [6 if img_num % 2 == 0 else 8][0]
         elif orientacion == "horizontal":
             orient = 1
 
@@ -124,10 +124,6 @@ class DescargarIMGS:
             fp.write(img.get_file())
 
         print(f"descargada img {jpg_path}")
-
-        # update bag
-        bag = bagit.Bag(os.path.join(IMGDIR, self.nombre_proyecto))
-        bag.save(manifests=True)
 
     def descarga_dng(self):
         '''
@@ -145,10 +141,6 @@ class DescargarIMGS:
                 self.associateImageWithElement(
                     self.nombre_proyecto, dng_path, 'dng')
                 print(f"descargada img {dng_path}")
-
-        # update bag
-        bag = bagit.Bag(os.path.join(IMGDIR, self.nombre_proyecto))
-        bag.save(manifests=True)
 
         self.dev.delete_files(img_path)
 
@@ -217,11 +209,21 @@ class DescargarIMGS:
             with open(metadata_path, 'w', encoding='utf-8') as fp:
                 json.dump({}, fp)
 
-        with open(metadata_path, 'r+', encoding='utf-8') as fp:
-            data = json.load(fp)
-            data[self.image_name(img_path)] = metadata
-            fp.seek(0)
-            json.dump(data, fp, indent=4, ensure_ascii=False)
+        try:
+            with open(metadata_path, 'r+', encoding='utf-8') as fp:
+                data = json.load(fp)
+                data[self.image_name(img_path)] = metadata
+                fp.seek(0)
+                json.dump(data, fp, indent=4, ensure_ascii=False)
+        except JSONDecodeError as e:
+            print("JSONDecodeError")
+            log.log(f"JSONDecodeError: {e} en {metadata_path}")
+            fixJSON.fixJSON(metadata_path)
+            with open(metadata_path, 'r+', encoding='utf-8') as fp:
+                data = json.load(fp)
+                data[self.image_name(img_path)] = metadata
+                fp.seek(0)
+                json.dump(data, fp, indent=4, ensure_ascii=False)
 
 
     def associateImageWithElement(self, metadata_text, img_path, tipo_img):
@@ -269,3 +271,14 @@ class DescargarIMGS:
         wrap_imageWithElement(element_id, order, size, mime_type, filename,
                               path, img_timestamp, img_modified_ts,
                               img_metadata)
+
+
+class UpdateFiles:
+
+    def __init__(self, nombre_proyecto):
+        self.nombre_proyecto = nombre_proyecto
+
+    def finish_and_update(self):
+        # update bag
+        bag = bagit.Bag(os.path.join(IMGDIR, self.nombre_proyecto))
+        bag.save(manifests=True)

--- a/main.py
+++ b/main.py
@@ -906,6 +906,7 @@ class MainWindow(QMainWindow):
             num_imagenes = len(os.listdir(folder_path))
         except FileNotFoundError:
             num_imagenes = 0
+        
         widgets.cantidadimgsLabel.setText(str(num_imagenes))
 
     def open_cameras(self):
@@ -1095,6 +1096,7 @@ class MainWindow(QMainWindow):
         movie.start()
         widgets.controlesCamstackedWidget.setCurrentWidget(
             widgets.validar)
+        app.processEvents()
 
         # Este loop permite que haya una espera de 10 segundos hasta que se permita una nueva toma
         if Cams.len_devs() > 1:
@@ -1123,6 +1125,9 @@ class MainWindow(QMainWindow):
         widgets.imagenizqLabel.setPixmap(QPixmap.fromImage(left_img))
         widgets.imagederLabel.setPixmap(QPixmap.fromImage(right_img))
 
+        self.lenImagenesDir(
+            Path(widgets.directorio_elementos.text(), 'data', 'JPG')) # Fix images count
+        
         widgets.statusLabel.setText(
             f"Capturadas {last_img_left} y {last_img_right}")
         log.log(

--- a/setup/config.cfg
+++ b/setup/config.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-version = 0.1.700
+version = 0.1.711
 img_dir = /home/pi/Documents/capturas
 last_update = 1700
 next_update = 1800

--- a/utils/fixJSON.py
+++ b/utils/fixJSON.py
@@ -1,0 +1,22 @@
+import json
+
+def fixJSON(path2JSON):
+    with open(path2JSON, "r") as fp:
+        readlines = fp.readlines()
+
+    # delete all \x00 characters
+
+    readlines = [line.replace("\x00", "") for line in readlines]
+
+    # join all lines
+
+    readlines = "".join(readlines)
+
+    # convert to json
+
+    readlines = json.loads(readlines)
+
+    # save new json file
+
+    with open(path2JSON, "w") as fp:
+        json.dump(readlines, fp, indent=4, ensure_ascii=False)

--- a/utils/monitor.py
+++ b/utils/monitor.py
@@ -1,0 +1,22 @@
+
+
+def promedio_captura():
+    """Calcula el promedio de captura de acuerdo con las últimas 10 capturas"""
+    # import log file
+
+    log =  open("logs/neoscan_log.log", "r")
+    lines = log.readlines()
+    # get lines where is substring "Tiempo total proceso descarga"
+    lines = [line for line in lines if "Tiempo total proceso descarga" in line]
+    # get last 10 lines
+    lines = lines[-10:]
+    # get time
+    times = [line.split(":")[-1].strip() for line in lines]
+    # get average
+    average = sum([float(time) for time in times]) / len(times)
+
+    return round(average, 2)
+
+
+if __name__ == "__main__":
+    print(promedio_captura())


### PR DESCRIPTION
## [0.1.711] - 2022-09-15

### Bugfixes

- Error en la orientación de las imágenes
- Correción del contador de imágenes en la patalla de Escaner
- Habilitación del comportamiento que oculta el botón de captura mientras se está capturando la imagen.
- Corregido un *bug* que hacía que después de una cantidad considerable de imágenes se incrementara el uso de la memoria RAM. Se corrigió modificando el comportamiento de *bagit* para que no se actualice el manifiesto con cada captura sino al cerrar el proyecto.
- Corrección de la orientación de las imágenes (se mostraban invertidas).
- Hallado error de sobreescritura. Se debía a un error no identificado por errores al guardar el archivo JSON que impedía identificar la siguiente imagen. Se creó un script para arreglar el archivo y poder continuar.